### PR TITLE
Add filtering page to black list projects in main view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /bower_components/
 /node_modules/
 /public/
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /bower_components/
 /node_modules/
 /public/
+.idea

--- a/app/assets/filtering.html
+++ b/app/assets/filtering.html
@@ -1,0 +1,25 @@
+<div class="columns">
+  <div class="row">
+    <h1 class="small-3 columns text-right">Filtering</h1>
+  </div>
+
+  <form novalidate>
+    <div class="row">
+      <div class="small-3 columns">
+        <label for="projects" class="text-right middle">Projects</label>
+      </div>
+      <div class="small-9 columns">
+        <div class="project" ng-repeat="project in vm.projects">
+          <p>{{project.name_with_namespace}}</p>
+          <button
+            type="button"
+            ng-click="vm.toggleBlackList(project)"
+            ng-class="{'disabled': project.black_listed}"
+          >
+            {{ project.black_listed ? 'Unblack list' : 'Black list'}}
+          </button>
+        </div>
+      </div>
+    </div>
+  </form>
+</div>

--- a/app/assets/index.html
+++ b/app/assets/index.html
@@ -17,6 +17,7 @@
       </div>
       <div class="top-bar-right">
           <ul class="menu">
+              <li><a href="#!/filtering">Filtering</a></li>
               <li><a href="#!/settings">Settings</a></li>
           </ul>
       </div>

--- a/app/js/application.js
+++ b/app/js/application.js
@@ -18,6 +18,11 @@ angular.module('app', [require('angular-tooltips'), require('angular-route'), re
       controller: 'SettingsCtrl',
       controllerAs: 'vm'
     })
+    .when('/filtering', {
+      templateUrl: 'filtering.html',
+      controller: 'FilteringCtrl',
+      controllerAs: 'vm'
+    })
     .otherwise({
       redirectTo: '/'
     });
@@ -36,9 +41,11 @@ angular.module('app', [require('angular-tooltips'), require('angular-route'), re
 .service('gitLabManager', ['configManager', '$http', '$q', require('./services/gitlab_manager')])
 .service('favicoService', require('./services/favico'))
 .service('MergeRequestFetcher', ['gitLabManager', 'configManager', '$q', '$http', require('./services/merge_request_fetcher')])
+.service('ProjectsFetcher', ['configManager', '$http', require('./services/projects_fetcher')])
 
 .controller('DashboardCtrl', ['$interval', 'MergeRequestFetcher', 'configManager', 'favicoService', require('./controllers/dashboard')])
 .controller('SettingsCtrl', ['gitLabManager', 'configManager', '$location', 'MergeRequestFetcher', require('./controllers/settings')])
+.controller('FilteringCtrl', ['configManager', 'ProjectsFetcher', require('./controllers/filtering')])
 
 .run(['$rootScope', 'gitLabManager', '$location', function($rootScope, gitLabManager, $location) {
   $rootScope.titleAddon = '';

--- a/app/js/controllers/dashboard.js
+++ b/app/js/controllers/dashboard.js
@@ -2,7 +2,12 @@ module.exports = function ($interval, MergeRequestFetcher, configManager, favico
   var vm = this;
   vm.refresh = function() {
     MergeRequestFetcher.getMergeRequests().then(function(mergeRequests) {
-      vm.mergeRequests = mergeRequests;
+      var blackListedProjectsIds = configManager.getBlackListedProjectsIds();
+
+      vm.mergeRequests = mergeRequests.filter(function (mergeRequest){
+        return blackListedProjectsIds.indexOf(mergeRequest.project_id) === -1;
+      });
+
       favicoService.badge(mergeRequests.length);
     });
   };

--- a/app/js/controllers/dashboard.js
+++ b/app/js/controllers/dashboard.js
@@ -4,7 +4,7 @@ module.exports = function ($interval, MergeRequestFetcher, configManager, favico
     MergeRequestFetcher.getMergeRequests().then(function(mergeRequests) {
       var blackListedProjectsIds = configManager.getBlackListedProjectsIds();
 
-      vm.mergeRequests = mergeRequests.filter(function (mergeRequest){
+      vm.mergeRequests = mergeRequests.filter(function (mergeRequest) {
         return blackListedProjectsIds.indexOf(mergeRequest.project_id) === -1;
       });
 

--- a/app/js/controllers/filtering.js
+++ b/app/js/controllers/filtering.js
@@ -2,13 +2,13 @@ module.exports = function (configManager, ProjectsFetcher) {
   var vm = this;
   vm.projects = [];
 
-  vm.toggleBlackList = function(project){
+  vm.toggleBlackList = function(project) {
     var blackListedProjectsIds = configManager.getBlackListedProjectsIds();
     var indexOfProject = blackListedProjectsIds.indexOf(project.id);
 
-    if(indexOfProject !== -1){
+    if (indexOfProject !== -1) {
       blackListedProjectsIds.splice(indexOfProject, 1)
-    }else {
+    } else {
       blackListedProjectsIds.push(project.id)
     }
 
@@ -16,7 +16,7 @@ module.exports = function (configManager, ProjectsFetcher) {
     project.black_listed = !project.black_listed;
   }
 
-  ProjectsFetcher.getProjects().then(function(projects){
+  ProjectsFetcher.getProjects().then(function(projects) {
     vm.projects = projects;
   })
 };

--- a/app/js/controllers/filtering.js
+++ b/app/js/controllers/filtering.js
@@ -1,0 +1,24 @@
+module.exports = function (configManager, ProjectsFetcher) {
+  var vm = this;
+  vm.projects = [];
+
+  vm.toggleBlackList = function(project){
+    var blackListedProjectsIds = configManager.getBlackListedProjectsIds();
+    var indexOfProject = blackListedProjectsIds.indexOf(project.id);
+
+    if(indexOfProject !== -1){
+      blackListedProjectsIds.splice(indexOfProject, 1)
+    }else {
+      blackListedProjectsIds.push(project.id)
+    }
+
+    configManager.setBlackListedProjectsIds(blackListedProjectsIds);
+    project.black_listed = !project.black_listed;
+  }
+
+  ProjectsFetcher.getProjects().then(function(projects){
+    vm.projects = projects;
+  })
+};
+
+

--- a/app/js/services/config_manager.js
+++ b/app/js/services/config_manager.js
@@ -47,5 +47,13 @@ module.exports = function(localStorageService) {
     localStorageService.remove('url', 'private_token');
   }
 
+  configManager.getBlackListedProjectsIds = function() {
+    return localStorageService.get('black_listed_projects_ids') || [];
+  }
+
+  configManager.setBlackListedProjectsIds = function(blackListProjectsIds) {
+    localStorageService.set('black_listed_projects_ids', blackListProjectsIds);
+  }
+
   return configManager;
 };

--- a/app/js/services/projects_fetcher.js
+++ b/app/js/services/projects_fetcher.js
@@ -1,0 +1,38 @@
+module.exports = function (configManager, $http) {
+  var ProjectsFetcher = {};
+  ProjectsFetcher.labels = {};
+
+  var request = function (url) {
+    return $http({
+      url: configManager.getUrl() + '/api/v4' + url,
+      headers:  {'PRIVATE-TOKEN': configManager.getPrivateToken()}
+    });
+  };
+
+  ProjectsFetcher.getProjects = function() {
+    var url = '/projects?page=1&per_page=100';
+    return request(url).then(function(response) {
+      var projects = formatProjectList(response.data);
+
+      return projects.sort(function(project1, project2) {
+
+        return project1.name_with_namespace.localeCompare(project2.name_with_namespace)
+      })
+    });
+  };
+
+  function formatProjectList(projects){
+    var blackListedProjectsIds = configManager.getBlackListedProjectsIds();
+
+    return projects.map(function(project){
+      if(blackListedProjectsIds.indexOf(project.id) !== -1){
+        project.black_listed = true;
+        return project;
+      }
+      project.black_listed = false;
+      return project;
+    });
+  }
+
+  return ProjectsFetcher;
+};

--- a/app/js/services/projects_fetcher.js
+++ b/app/js/services/projects_fetcher.js
@@ -21,11 +21,11 @@ module.exports = function (configManager, $http) {
     });
   };
 
-  function formatProjectList(projects){
+  function formatProjectList(projects) {
     var blackListedProjectsIds = configManager.getBlackListedProjectsIds();
 
-    return projects.map(function(project){
-      if(blackListedProjectsIds.indexOf(project.id) !== -1){
+    return projects.map(function(project) {
+      if (blackListedProjectsIds.indexOf(project.id) !== -1) {
         project.black_listed = true;
         return project;
       }

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -90,3 +90,25 @@ label, fieldset > legend {
 h1 {
     margin-bottom: 25px;
 }
+
+button {
+    padding: 2px 8px;
+    border-radius: 5px!important;
+    border: 1px solid $primary-color;
+    color: $primary-color;
+    height: max-content;
+
+    &.disabled {
+        border-color: gray;
+        color: gray;
+    }
+}
+
+.project {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    p{
+        display: inline-block;
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3638,7 +3638,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3659,12 +3660,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3679,17 +3682,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3806,7 +3812,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3818,6 +3825,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3832,6 +3840,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3839,12 +3848,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3863,6 +3874,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3950,7 +3962,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3962,6 +3975,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4047,7 +4061,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4083,6 +4098,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4102,6 +4118,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4145,12 +4162,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
#### Description

Add a new system to filter out projects from the dashboard.
It adds a new page called "Filtering" which shows current projects of the gitlab server.
These projects can be switched on or off to be filtered from the dashboard page.
The selected filtered ("blacklisted") projects are then stored in the localStorage of the client.

#### Resume

* Bug fix: no
* New feature: yes
